### PR TITLE
change path definition in example

### DIFF
--- a/examples/ca-presidentials.py
+++ b/examples/ca-presidentials.py
@@ -1,10 +1,12 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
+import os
 import prince
 
-
-df = pd.read_csv('data/presidentielles07.csv', index_col=0)
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/presidentielles07.csv')
+df = pd.read_csv(absolute_path, index_col=0)
 
 ca = prince.CA(df, n_components=-1)
 

--- a/examples/ca-woman-work.py
+++ b/examples/ca-woman-work.py
@@ -1,10 +1,12 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
+import os
 import prince
 
-
-df = pd.read_csv('data/woman_work.csv', index_col=0)
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/woman_work.csv')
+df = pd.read_csv(absolute_path, index_col=0)
 df = df[['Stay at home','Part-time work','Full-time work']]
 
 ca = prince.CA(df, n_components=-1)

--- a/examples/mca-ogm.py
+++ b/examples/mca-ogm.py
@@ -1,10 +1,12 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
+import os
 import prince
 
-
-df = pd.read_csv('data/ogm.csv')
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/ogm.csv')
+df = pd.read_csv(absolute_path)
 
 mca = prince.MCA(df, n_components=-1)
 

--- a/examples/pca-decathlon.py
+++ b/examples/pca-decathlon.py
@@ -1,11 +1,14 @@
 import pandas as pd
 import matplotlib.pyplot as plt
 
+import os
 import prince
 
-
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/decathlon.csv')
 # Load a dataframe
-df = pd.read_csv('data/decathlon.csv', index_col=0)
+df = pd.read_csv(absolute_path, index_col=0)
+
 
 # Compute the PCA
 pca = prince.PCA(df, n_components=-1, supplementary_rows=['Uldal'],

--- a/examples/pca-iris.py
+++ b/examples/pca-iris.py
@@ -1,9 +1,11 @@
 import pandas as pd
 
+import os
 import prince
 
-
-df = pd.read_csv('data/iris.csv')
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/iris.csv')
+df = pd.read_csv(absolute_path)
 
 pca = prince.PCA(df, n_components=4)
 

--- a/examples/pca-wine.py
+++ b/examples/pca-wine.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 
+import os
 import prince
 
 wines = {
@@ -9,7 +10,10 @@ wines = {
     3: 'barbera'
 }
 
-df = pd.read_csv('data/wine.csv')
+org_dir = os.path.dirname(__file__)
+absolute_path = os.path.join(org_dir, 'data/wine.csv')
+df = pd.read_csv(absolute_path)
+
 df['kind'] = df['class'].apply(lambda x: wines[x])
 df.drop('class', axis=1, inplace=True)
 


### PR DESCRIPTION
Hello, I changed path data to absolute one, for some bug.
Currently, examples run when
```
$ cd example
$ python xxx.py
```
but not when
```
$ python example/xxx.py
```
How do you think about it? I'm not an python expert, so don't hesitate to talk about it if there is any problem.
Thanks.