### PR TITLE
Fix AttributeError on ListedColormap from_list method

### DIFF
--- a/prince/plot/mpl/util.py
+++ b/prince/plot/mpl/util.py
@@ -13,7 +13,7 @@ def create_discrete_cmap(n):
         base = plt.cm.get_cmap('Paired')
         color_list = base([(i + 1) / (n + 1) for i in range(n)])
         cmap_name = base.name + str(n)
-        return base.from_list(cmap_name, color_list, n)
+        return clr.LinearSegmentedColormap.from_list(cmap_name, color_list, n)
     return clr.ListedColormap(colors)
 
 


### PR DESCRIPTION
Executing `python mca-ogm.py` crashed with the following error:
```
Traceback (most recent call last):
  File "mca-ogm.py", line 14, in <module>
    fig3, ax3 = mca.plot_rows_columns()
  File "/home/mario/Dokumente/dev/Prince/prince/mca.py", line 181, in plot_rows_columns
    show_column_labels=show_column_labels
  File "/home/mario/Dokumente/dev/Prince/prince/plot/mpl/mca.py", line 53, in row_column_principal_coordinates
    cmap = mpl_util.create_discrete_cmap(n_colors)
  File "/home/mario/Dokumente/dev/Prince/prince/plot/mpl/util.py", line 16, in create_discrete_cmap
    return base.from_list(cmap_name, color_list, n)
AttributeError: 'ListedColormap' object has no attribute 'from_list'
```

This PR fixes the crash by calling the static method `from_list` on the `LinearSegmentedColormap` object, instead of `base`.