### PR TITLE
fixed KeyError when index is not a range

### DIFF
--- a/prince/ca.py
+++ b/prince/ca.py
@@ -177,15 +177,15 @@ class CA(base.BaseEstimator, base.TransformerMixin):
         if show_row_labels:
             x = row_coords[x_component]
             y = row_coords[y_component]
-            for i, label in enumerate(row_names):
-                ax.annotate(label, (x[i], y[i]))
+            for xi, yi, label in zip(x, y, row_names):
+                ax.annotate(label, (xi, yi))
 
         # Add column labels
         if show_col_labels:
             x = col_coords[x_component]
             y = col_coords[y_component]
-            for i, label in enumerate(col_names):
-                ax.annotate(label, (x[i], y[i]))
+            for xi, yi, label in zip(x, y, col_names):
+                ax.annotate(label, (xi, yi))
 
         # Legend
         ax.legend()

--- a/prince/pca.py
+++ b/prince/pca.py
@@ -236,8 +236,8 @@ class PCA(base.BaseEstimator, base.TransformerMixin):
 
         # Add labels
         if labels is not None:
-            for i, label in enumerate(labels):
-                ax.annotate(label, (x[i], y[i]))
+            for xi, yi, label in zip(x, y, labels):
+                ax.annotate(label, (xi, yi))
 
         # Legend
         ax.legend()


### PR DESCRIPTION
When a `DataFrame` is used for CA and its index is not a continuous range (eg, `[0, 1, 3, 4]` without the 2), using `enumerate` in `plot_coordinate` raises a `KeyError`. I've replaced with an explicit `zip` of the needed values that does not need to assume their index.

I suspect the same problem will occur with PCA, I'll look at it.