### PR TITLE
Updated travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ install:
   - pip install -r requirements.dev.txt
   - pip install codecov
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
+services:
+  - xvfb
 
 script:
   - pytest --cov prince


### PR DESCRIPTION
I edited the travis file. It seems like for any code change, it would always fail in the CI with the following message : "Can't open /etc/init.d/xvfb The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during . "
This is due to a change in the way travis launches XVFB (the issue it described [here](https://benlimmer.com/2019/01/14/travis-ci-xvfb/) for instance). 