### PR TITLE
Replace the check for SparseDataFrame in CA

### DIFF
--- a/prince/ca.py
+++ b/prince/ca.py
@@ -138,10 +138,12 @@ class CA(base.BaseEstimator, base.TransformerMixin):
 
         _, _, _, col_names = util.make_labels_and_names(X)
 
-        if X.dtypes.apply(pd.api.types.is_sparse).all():
-            X = X.sparse.to_coo()
-        else:
-            X = X.to_numpy()
+        if isinstance(X, pd.DataFrame):
+            is_sparse = X.dtypes.apply(pd.api.types.is_sparse).all()
+            if is_sparse:
+                X = X.sparse.to_coo()
+            else:
+                X = X.to_numpy()
 
         if self.copy:
             X = X.copy()

--- a/prince/ca.py
+++ b/prince/ca.py
@@ -138,9 +138,9 @@ class CA(base.BaseEstimator, base.TransformerMixin):
 
         _, _, _, col_names = util.make_labels_and_names(X)
 
-        if isinstance(X, pd.SparseDataFrame):
-            X = X.to_coo()
-        elif isinstance(X, pd.DataFrame):
+        if X.dtypes.apply(pd.api.types.is_sparse).all():
+            X = X.sparse.to_coo()
+        else:
             X = X.to_numpy()
 
         if self.copy:


### PR DESCRIPTION
On pandas>=1.0.0 SparseDataFrame were removed, I replace the check for this type of dataframe with a check for the new SparseArray data structure over all columns.