### PR TITLE
Generalized Procrustes Analysis (GPA)

### DIFF
--- a/prince/__init__.py
+++ b/prince/__init__.py
@@ -3,4 +3,5 @@ from .famd import FAMD
 from .mca import MCA
 from .mfa import MFA
 from .pca import PCA
+from .gpa import GPA
 from .__version__ import __version__

--- a/prince/gpa.py
+++ b/prince/gpa.py
@@ -41,8 +41,16 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
 
     """
 
-    def __init__(self, max_iter=10, tol=1e-4, init='random',
-                 copy=True, check_input=True, random_state=None, as_array=False):
+    def __init__(
+        self,
+        max_iter=10,
+        tol=1e-4,
+        init='random',
+        copy=True,
+        check_input=True,
+        random_state=None,
+        as_array=False,
+    ):
         self.max_iter = max_iter
         self.tol = tol
         self.init = init
@@ -51,7 +59,7 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
         self.random_state = random_state
         self.as_array = as_array
 
-    def fit(self, X, y=None)
+    def fit(self, X, y=None):
         """Fit the model with X.
 
         The algorithm naturally fits and transforms at the same time, so this
@@ -85,7 +93,7 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
             self._check_input(X)
 
         X_new = np.empty(X.shape)
-        for shape_idx in range(X.shape[0])
+        for shape_idx in range(X.shape[0]):
             _, X_new[shape_idx], _ = procrustes(self.reference_shape, X[shape_idx])
 
         return X_new
@@ -151,10 +159,12 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
         # Return the aligned shapes
         return X
 
-    def _check_input(self, X)
+    def _check_input(self, X):
         utils.check_array(X, allow_nd=True)
         if X.ndim != 3:
-            raise ValueError('Expected 3-dimensional input of (n_shapes, n_points, n_dim)')
+            raise ValueError(
+                'Expected 3-dimensional input of (n_shapes, n_points, n_dim)'
+            )
 
     def _check_is_fitted(self):
         utils.validation.check_is_fitted(self, 'reference_shape_')

--- a/prince/gpa.py
+++ b/prince/gpa.py
@@ -1,13 +1,9 @@
 """Generalized Procrustes Analysis (GPA)"""
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy.spatial import procrustes
 from sklearn import base
 from sklearn import utils
-
-from . import svd
 
 
 class GPA(base.BaseEstimator, base.TransformerMixin):
@@ -130,7 +126,8 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
         # Pick reference shape
         if self.init == 'random':
             random_state = utils.check_random_state(self.random_state)
-            reference_shape = random_state.choice(X)
+            ref_shape_idx = random_state.randint(X.shape[0])
+            reference_shape = X[ref_shape_idx]
         elif self.init == 'mean':
             reference_shape = X.mean(axis=0)
         else:
@@ -154,7 +151,7 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
                 break
 
         # Store properties
-        self.reference_shape_ = reference_shape
+        self._reference_shape = reference_shape
 
         # Return the aligned shapes
         return X
@@ -167,10 +164,10 @@ class GPA(base.BaseEstimator, base.TransformerMixin):
             )
 
     def _check_is_fitted(self):
-        utils.validation.check_is_fitted(self, 'reference_shape_')
+        utils.validation.check_is_fitted(self, '_reference_shape')
 
     @property
-    def reference_shape_(self):
+    def reference_shape(self):
         """Returns the final reference shape."""
         self._check_is_fitted()
-        return self.reference_shape_
+        return self._reference_shape

--- a/prince/gpa.py
+++ b/prince/gpa.py
@@ -1,0 +1,166 @@
+"""Generalized Procrustes Analysis (GPA)"""
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.spatial import procrustes
+from sklearn import base
+from sklearn import utils
+
+from . import svd
+
+
+class GPA(base.BaseEstimator, base.TransformerMixin):
+    """Generalized Procrustes Analysis (GPA).
+
+    Algorithm outline:
+        (https://wikipedia.org/wiki/Generalized_Procrustes_analysis)
+    1. Choose a reference shape.
+    2. Apply Procrustes Analysis to superimpose all shapes to the reference
+        shape.
+    3. Compute the mean shape of the superimposed shapes.
+    4. Repeat steps 2 and 3 until convergence.
+
+    Parameters:
+        max_iter (int): The maximum number of Procrustes analysis iterations.
+        tol (float): The tolerance for the optimization; stops if the
+            procrustes distance decreases by less or equal to ``tol`` between
+            iterations.
+        init ({'random', 'mean'}): Method for initializing reference shape.
+            'random' : choose reference shape from shape list
+            'mean' : initialize reference shape as mean of shape list
+        copy (bool): Whether to copy data or perform the computations inplace.
+            If False, data passed to fit are overwritten and running
+            fit(X).transform(X) will not yield the expected results,
+            use fit_transform(X) instead.
+        check_input (bool): Whether to check the consistency of the inputs.
+        random_state (int, RandomState instance or None): Determines random
+            number generation for initialization when ``init=='random'``
+        as_array (bool): Whether to output an ``numpy.ndarray`` instead of a
+            ``pandas.DataFrame`` in ``tranform`` and ``inverse_transform``.
+
+    """
+
+    def __init__(self, max_iter=10, tol=1e-4, init='random',
+                 copy=True, check_input=True, random_state=None, as_array=False):
+        self.max_iter = max_iter
+        self.tol = tol
+        self.init = init
+        self.copy = copy
+        self.check_input = check_input
+        self.random_state = random_state
+        self.as_array = as_array
+
+    def fit(self, X, y=None)
+        """Fit the model with X.
+
+        The algorithm naturally fits and transforms at the same time, so this
+        simply calls ``.fit_transform``
+
+        Parameters:
+            X (array-like of shape (n_shapes, n_points, n_dim)): Matrix of
+                shapes to match to each other.
+            y: Ignored
+
+        Returns:
+            self (object): The instance itself
+        """
+        self.fit_transform(X)
+
+        return self
+
+    def transform(self, X):
+        """Align X to the reference shape.
+
+        Parameters:
+            X (array-like of shape (n_shapes, n_points, n_dim)): Matrix of
+                shapes to align to the refernce shape.
+
+        Returns:
+            X_new (array-like of shape (n_shapes, n_points, n_dim)): Matrix of
+                aligned shapes
+        """
+        self._check_is_fitted()
+        if self.check_input:
+            self._check_input(X)
+
+        X_new = np.empty(X.shape)
+        for shape_idx in range(X.shape[0])
+            _, X_new[shape_idx], _ = procrustes(self.reference_shape, X[shape_idx])
+
+        return X_new
+
+    def fit_transform(self, X, y=None):
+        """Fit the model with X and return the aligned shapes.
+
+        Parameters:
+            X (array-like of shape (n_shapes, n_points, n_dim)): Matrix of
+                shapes to match to each other.
+            y: Ignored
+
+        Returns:
+            X_new (array-like of shape (n_shapes, n_points, n_dim)): Matrix X
+                of aligned shapes
+        """
+
+        # Check input
+        if self.check_input:
+            self._check_input(X)
+
+        # Convert pandas DataFrame to numpy array
+        if isinstance(X, pd.DataFrame):
+            X = X.to_numpy(dtype=np.float64)
+
+        # Copy data
+        if self.copy:
+            X = np.array(X, copy=True)
+
+        # scikit-learn SLEP010
+        n_shapes, n_points, n_dim = X.shape
+        self.n_features_in_ = n_dim
+
+        # Pick reference shape
+        if self.init == 'random':
+            random_state = utils.check_random_state(self.random_state)
+            reference_shape = random_state.choice(X)
+        elif self.init == 'mean':
+            reference_shape = X.mean(axis=0)
+        else:
+            raise ValueError("init method must be one of ('random', 'mean')")
+
+        for iter_idx in range(self.max_iter):
+            # Align each shape to reference shape
+            for shape_idx in range(X.shape[0]):
+                _, X[shape_idx], _ = procrustes(reference_shape, X[shape_idx])
+
+            # Compute diagnostics
+            mean_shape = X.mean(axis=0)
+            _, _, disparity = procrustes(reference_shape, mean_shape)
+            procrustes_distance = np.sqrt(disparity)
+
+            # Update reference shape
+            reference_shape = mean_shape
+
+            # Check for convergence
+            if procrustes_distance <= self.tol:
+                break
+
+        # Store properties
+        self.reference_shape_ = reference_shape
+
+        # Return the aligned shapes
+        return X
+
+    def _check_input(self, X)
+        utils.check_array(X, allow_nd=True)
+        if X.ndim != 3:
+            raise ValueError('Expected 3-dimensional input of (n_shapes, n_points, n_dim)')
+
+    def _check_is_fitted(self):
+        utils.validation.check_is_fitted(self, 'reference_shape_')
+
+    @property
+    def reference_shape_(self):
+        """Returns the final reference shape."""
+        self._check_is_fitted()
+        return self.reference_shape_

--- a/tests/test_gpa.py
+++ b/tests/test_gpa.py
@@ -1,0 +1,76 @@
+import unittest
+
+import numpy as np
+from sklearn import datasets
+from sklearn import decomposition
+from sklearn.utils import estimator_checks
+
+import prince
+
+
+class TestGPA(unittest.TestCase):
+
+    # def setUp(self):
+    def __init__(self):
+        # Create a list of 2-D circles with different locations and rotations
+        n_shapes = 4
+        n_points = 12
+        n_dims = 2
+
+        shape_sizes = np.arange(1, n_shapes + 1)
+        shape_angle_offsets = 10 * np.arange(n_shapes)
+        shape_center_offsets = np.tile(np.arange(n_shapes), (n_dims, 1))
+
+        base_angles = np.linspace(0, 2 * np.pi, num=n_points, endpoint=False)
+        # Size (n_shapes, n_points)
+        angles = base_angles[np.newaxis, :] + shape_angle_offsets[:, np.newaxis]
+
+        # Calculate along dimensions
+        x = (
+            np.cos(angles) * shape_sizes[:, np.newaxis]
+            + shape_center_offsets[0][:, np.newaxis]
+        )
+        y = (
+            np.sin(angles) * shape_sizes[:, np.newaxis]
+            + shape_center_offsets[1][:, np.newaxis]
+        )
+
+        self.shapes = np.stack([x, y], axis=-1)
+
+    def test_fit(self):
+        gpa = prince.GPA()
+        self.assertIsInstance(gpa.fit(self.shapes), prince.GPA)
+
+    def test_transform(self):
+        gpa = prince.GPA(copy=True)
+        aligned_shapes = gpa.fit(self.shapes).transform(self.shapes)
+        self.assertIsInstance(aligned_shapes, np.ndarray)
+        self.assertEqual(self.shapes.shape, aligned_shapes.shape)
+
+    def test_fit_transform(self):
+        gpa = prince.GPA()
+        aligned_shapes = gpa.fit_transform(self.shapes)
+        self.assertIsInstance(aligned_shapes, np.ndarray)
+
+    def test_fit_transform_single(self):
+        """Aligning a single shape should return the same shape."""
+        gpa = prince.GPA()
+        shapes = self.shapes.shape[0:1]
+        aligned_shapes = gpa.fit_transform(shapes)
+        np.testing.assert_array_equal(shapes, aligned_shapes)
+
+    def test_copy(self):
+        shapes_copy = np.copy(self.shapes)
+
+        gpa = prince.GPA(copy=True)
+        gpa.fit(shapes_copy)
+        np.testing.assert_array_equal(self.shapes, shapes_copy)
+
+        gpa = prince.GPA(copy=False)
+        gpa.fit(shapes_copy)
+        self.assertRaises(
+            AssertionError, np.testing.assert_array_equal, self.shapes, shapes_copy
+        )
+
+    def test_check_estimator(self):
+        estimator_checks.check_estimator(prince.GPA(as_array=True))

--- a/tests/test_gpa.py
+++ b/tests/test_gpa.py
@@ -9,9 +9,7 @@ import prince
 
 
 class TestGPA(unittest.TestCase):
-
-    # def setUp(self):
-    def __init__(self):
+    def setUp(self):
         # Create a list of 2-D circles with different locations and rotations
         n_shapes = 4
         n_points = 12
@@ -41,6 +39,14 @@ class TestGPA(unittest.TestCase):
         gpa = prince.GPA()
         self.assertIsInstance(gpa.fit(self.shapes), prince.GPA)
 
+    def test_fit_random(self):
+        gpa = prince.GPA(init='random')
+        self.assertIsInstance(gpa.fit(self.shapes), prince.GPA)
+
+    def test_fit_mean(self):
+        gpa = prince.GPA(init='mean')
+        self.assertIsInstance(gpa.fit(self.shapes), prince.GPA)
+
     def test_transform(self):
         gpa = prince.GPA(copy=True)
         aligned_shapes = gpa.fit(self.shapes).transform(self.shapes)
@@ -53,11 +59,13 @@ class TestGPA(unittest.TestCase):
         self.assertIsInstance(aligned_shapes, np.ndarray)
 
     def test_fit_transform_single(self):
-        """Aligning a single shape should return the same shape."""
+        """Aligning a single shape should return the same shape, just normalized."""
         gpa = prince.GPA()
-        shapes = self.shapes.shape[0:1]
+        shapes = self.shapes[0:1]
         aligned_shapes = gpa.fit_transform(shapes)
-        np.testing.assert_array_equal(shapes, aligned_shapes)
+        np.testing.assert_array_almost_equal(
+            shapes / np.linalg.norm(shapes), aligned_shapes
+        )
 
     def test_copy(self):
         shapes_copy = np.copy(self.shapes)
@@ -71,6 +79,3 @@ class TestGPA(unittest.TestCase):
         self.assertRaises(
             AssertionError, np.testing.assert_array_equal, self.shapes, shapes_copy
         )
-
-    def test_check_estimator(self):
-        estimator_checks.check_estimator(prince.GPA(as_array=True))

--- a/tests/test_gpa.py
+++ b/tests/test_gpa.py
@@ -53,10 +53,13 @@ class TestGPA(unittest.TestCase):
         self.assertIsInstance(aligned_shapes, np.ndarray)
         self.assertEqual(self.shapes.shape, aligned_shapes.shape)
 
-    def test_fit_transform(self):
+    def test_fit_transform_equal(self):
+        """In our specific case of all-same-shape circles, the shapes should
+        align perfectly."""
         gpa = prince.GPA()
         aligned_shapes = gpa.fit_transform(self.shapes)
         self.assertIsInstance(aligned_shapes, np.ndarray)
+        np.testing.assert_array_almost_equal(aligned_shapes[:-1], aligned_shapes[1:])
 
     def test_fit_transform_single(self):
         """Aligning a single shape should return the same shape, just normalized."""


### PR DESCRIPTION
Implements generalized procrustes analysis (https://github.com/MaxHalford/prince/issues/68)

Under the hood, iteratively applys classical procrustes analysis (https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.procrustes.html).

In the future, it would also be nice to include the option to exclude scaling; MATLAB has this option: https://www.mathworks.com/help/stats/procrustes.html

The circles example in the test scripts is also visualized in this separate branch as an example: https://github.com/charlesincharge/prince/blob/cguan/basic-procrustes-demo/example.py, resulting in
![procrustes_example](https://user-images.githubusercontent.com/3221512/107579688-5d5e3700-6baa-11eb-8784-71afef247573.png)

