### PR TITLE
Use Benzécri and Greenacre corrections in MCA.

### DIFF
--- a/prince/ca.py
+++ b/prince/ca.py
@@ -13,14 +13,13 @@ from . import svd
 
 class CA(base.BaseEstimator, base.TransformerMixin):
 
-    def __init__(self, n_components=2, n_iter=10, copy=True, check_input=True, benzecri=False,
+    def __init__(self, n_components=2, n_iter=10, copy=True, check_input=True,
                  random_state=None, engine='auto'):
         self.n_components = n_components
         self.n_iter = n_iter
         self.copy = copy
         self.check_input = check_input
         self.random_state = random_state
-        self.benzecri = benzecri
         self.engine = engine
 
     def fit(self, X, y=None):
@@ -85,21 +84,8 @@ class CA(base.BaseEstimator, base.TransformerMixin):
 
     @property
     def eigenvalues_(self):
-        """The eigenvalues associated with each principal component.
-
-        Benzecri correction is applied if specified.
-
-        """
+        """The eigenvalues associated with each principal component."""
         self._check_is_fitted()
-
-        K = len(self.col_masses_)
-
-        if self.benzecri:
-            return np.array([
-                (K / (K - 1.) * (s - 1. / K)) ** 2
-                if s > 1. / K else 0
-                for s in np.square(self.s_)
-            ])
 
         return np.square(self.s_).tolist()
 

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -4,6 +4,7 @@ https://www.utdallas.edu/~herve/Abdi-MCA2007-pretty.pdf
 import unittest
 
 import matplotlib as mpl
+import numpy as np
 import pandas as pd
 
 import prince
@@ -14,12 +15,12 @@ class TestMCA(unittest.TestCase):
     def setUp(self):
         self.X = pd.DataFrame(
             data=[
-                [0, 'C', 1, 0, 1, 'C', 1, 1, 1, 1],
-                [1, 'B', 0, 1, 0, 'B', 0, 1, 0, 0],
-                [1, 'A', 0, 1, 0, 'A', 0, 1, 0, 0],
-                [1, 'A', 0, 1, 0, 'A', 0, 0, 0, 0],
-                [0, 'C', 1, 0, 1, 'C', 1, 0, 1, 1],
-                [0, 'B', 1, 0, 1, 'B', 1, 0, 1, 1]
+                ['N', 'C', 'Y', 'N', 'Y', 'C', 'Y', 'Y', 'Y', 'Y'],
+                ['Y', 'B', 'N', 'Y', 'N', 'B', 'N', 'Y', 'N', 'N'],
+                ['Y', 'A', 'N', 'Y', 'N', 'A', 'N', 'Y', 'N', 'N'],
+                ['Y', 'A', 'N', 'Y', 'N', 'A', 'N', 'N', 'N', 'N'],
+                ['N', 'C', 'Y', 'N', 'Y', 'C', 'Y', 'N', 'Y', 'Y'],
+                ['N', 'B', 'Y', 'N', 'Y', 'B', 'Y', 'N', 'Y', 'Y']
             ],
             columns=['E1 fruity', 'E1 woody', 'E1 coffee',
                      'E2 red fruit', 'E2 roasted', 'E2 vanillin', 'E2 woody',
@@ -48,3 +49,20 @@ class TestMCA(unittest.TestCase):
         mca.fit(self.X)
         ax = mca.plot_coordinates(self.X, show_column_labels=True)
         self.assertTrue(isinstance(ax, mpl.axes.Axes))
+
+    def test_eigenvalues_are_corrected(self):
+        mca = prince.MCA(n_components=4, random_state=42)
+        mca.fit(self.X)
+        self.assertEquals(mca.K, 10)
+        np.testing.assert_allclose(mca.eigenvalues_, [.7004, .0123, .0003, 0 ], atol=0.0001)
+
+    def test_total_inertia(self):
+        mca = prince.MCA(n_components=4, random_state=42)
+        mca.fit(self.X)
+        np.testing.assert_almost_equal(mca.total_inertia_, 0.7130, 4)    
+
+    def test_explained_inertia(self):
+        mca = prince.MCA(n_components=4, random_state=42)
+        mca.fit(self.X)
+        self.assertEquals(mca.J, 22)
+        np.testing.assert_allclose(mca.explained_inertia_, [.9519, .0168, .0004, 0 ], atol=0.0001)


### PR DESCRIPTION
Hi,

This PR corrects the Benzécri correction to the MCA eigenvalues (as reported in issue #103). It also makes the explained_inertia and total_inertia return meaningful results for MCAs. (And it applies the Greenacre correction to the explained inertia.) I added tests that match the expected values from the referenced paper. 

I considered adding tests for the coordinates methods, but it seems that the SVD returned by sklearn and fbpca doesn't come up with the same decomposition than the numbers in the paper. (The eigenvalues match, but the left (U) and right (V) matrices are in all likelihood different.

As the Benzécri correction doesn't apply to regular CA, I removed that parameter, and didn't make it optional in MCA, as I don't see a compelling reason why someone wouldn't want to apply these corrections. 

Thanks!