### PR TITLE
Update normalization of categorical features

### DIFF
--- a/prince/famd.py
+++ b/prince/famd.py
@@ -63,15 +63,15 @@ class FAMD(pca.PCA):
             columns=self.cat_scaler_.get_feature_names_out(self.cat_cols_),
         )
         Xd = X_cat_oh.sparse.to_dense().fillna(0.0)  # ensures true 0/1 matrix
-        prop = Xd.sum() / Xd.to_numpy().sum() * 2
-        X_cat_oh_norm = Xd.sub(Xd.mean(axis="rows")).div(prop**0.5, axis="columns")
+        prop = Xd.sum() / Xd.sum().sum() * 2
+        Xd_norm = Xd.sub(Xd.mean(axis="rows")).div(prop**0.5, axis="columns")
 
         # PCA.fit doesn't work with sparse matrices. Well, it accepts them, but it densifies them.
         # We pre-densify them here to avoid a warning.
         # TODO: In the future, PCA should be able to handle sparse matrices.
         # X_cat_oh_norm = X_cat_oh_norm.sparse.to_dense() # This should already be dense
 
-        Z = pd.concat([X_num, X_cat_oh_norm], axis=1)
+        Z = pd.concat([X_num, Xd_norm], axis=1)
         super().fit(Z)
 
         # Determine column_coordinates_
@@ -111,10 +111,11 @@ class FAMD(pca.PCA):
             index=X_cat.index,
             columns=self.cat_scaler_.get_feature_names_out(self.cat_cols_),
         )
-        prop = X_cat.sum() / X_cat.sum().sum() * 2
-        X_cat = X_cat.sub(X_cat.mean(axis="rows")).div(prop**0.5, axis="columns")
+        Xd = X_cat.sparse.to_dense().fillna(0.0)  # ensures true 0/1 matrix
+        prop = Xd.sum() / Xd.sum().sum() * 2
+        Xd = Xd.sub(Xd.mean(axis="rows")).div(prop**0.5, axis="columns")
 
-        Z = pd.concat([X_num, X_cat.sparse.to_dense()], axis=1).fillna(0.0)
+        Z = pd.concat([X_num, Xd], axis=1).fillna(0.0)
 
         return super().row_coordinates(Z)
 

--- a/prince/famd.py
+++ b/prince/famd.py
@@ -62,13 +62,14 @@ class FAMD(pca.PCA):
             index=X_cat.index,
             columns=self.cat_scaler_.get_feature_names_out(self.cat_cols_),
         )
-        prop = X_cat_oh.sum() / X_cat_oh.sum().sum() * 2
-        X_cat_oh_norm = X_cat_oh.sub(X_cat_oh.mean(axis="rows")).div(prop**0.5, axis="columns")
+        Xd = X_cat_oh.sparse.to_dense().fillna(0.0)  # ensures true 0/1 matrix
+        prop = Xd.sum() / Xd.to_numpy().sum() * 2
+        X_cat_oh_norm = Xd.sub(Xd.mean(axis="rows")).div(prop**0.5, axis="columns")
 
         # PCA.fit doesn't work with sparse matrices. Well, it accepts them, but it densifies them.
         # We pre-densify them here to avoid a warning.
         # TODO: In the future, PCA should be able to handle sparse matrices.
-        X_cat_oh_norm = X_cat_oh_norm.sparse.to_dense()
+        # X_cat_oh_norm = X_cat_oh_norm.sparse.to_dense() # This should already be dense
 
         Z = pd.concat([X_num, X_cat_oh_norm], axis=1)
         super().fit(Z)


### PR DESCRIPTION
Recent versions of Pandas set the default value in sparse matrices to NaN instead of zero, which will throw a ValueError when we try to run fit(). Force those values to zero to ensure compatibility with all versions of Pandas.