### PR TITLE
Use random_state in svd for fbpca

### DIFF
--- a/prince/svd.py
+++ b/prince/svd.py
@@ -41,6 +41,8 @@ def compute_svd(
     # Compute the SVD
     if engine == "fbpca":
         if FBPCA_INSTALLED:
+            if random_state:
+                np.random.seed(random_state)
             U, s, V = fbpca.pca(X, k=n_components, n_iter=n_iter)
         else:
             raise ValueError("fbpca is not installed; please install it if you want to use it")

--- a/prince/svd.py
+++ b/prince/svd.py
@@ -42,8 +42,11 @@ def compute_svd(
     if engine == "fbpca":
         if FBPCA_INSTALLED:
             if random_state:
+                state = np.random.get_state()
                 np.random.seed(random_state)
             U, s, V = fbpca.pca(X, k=n_components, n_iter=n_iter)
+            if random_state:
+                np.random.set_state(state)
         else:
             raise ValueError("fbpca is not installed; please install it if you want to use it")
     elif engine == "scipy":


### PR DESCRIPTION
If the user passes a random_state to the pca calculation, we should actually use it for fbpca. There was a recent upstream change that caused the PCA output to always be the exact same even if we set a random_state.