### PR TITLE
Fix PCA supplementary column coordinates (closes #228)

### DIFF
--- a/prince/pca.py
+++ b/prince/pca.py
@@ -107,11 +107,15 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
             ).fit(X_active, sample_weight=sample_weight)
             X_active = self.scaler_.transform(X_active)  # TODO: maybe fit_transform is faster
             if supplementary_columns:
-                X_sup = preprocessing.StandardScaler(
-                    copy=self.copy,
-                    with_mean=self.rescale_with_mean,
-                    with_std=self.rescale_with_std,
-                ).fit_transform(X_sup)
+                X_sup = (
+                    preprocessing.StandardScaler(
+                        copy=self.copy,
+                        with_mean=self.rescale_with_mean,
+                        with_std=self.rescale_with_std,
+                    )
+                    .fit(X_sup, sample_weight=sample_weight)
+                    .transform(X_sup)
+                )
 
         self._column_dist = pd.Series(
             (X_active**2 * sample_weight[:, np.newaxis]).sum(axis=0),
@@ -122,7 +126,7 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
                 (
                     self._column_dist,
                     pd.Series(
-                        (X_sup**2 / len(X_sup)).sum(axis=0),
+                        (X_sup**2 * sample_weight[:, np.newaxis]).sum(axis=0),
                         index=supplementary_columns,
                     ),
                 )
@@ -151,7 +155,7 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
                 [
                     self.column_coordinates_,
                     pd.DataFrame(
-                        data=X_sup.T @ (self.svd_.U / len(self.svd_.U) ** 0.5),
+                        data=X_sup.T @ (sample_weight[:, np.newaxis] * self.svd_.U),
                         index=supplementary_columns,
                     ),
                 ]

--- a/prince/pca.py
+++ b/prince/pca.py
@@ -107,15 +107,11 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
             ).fit(X_active, sample_weight=sample_weight)
             X_active = self.scaler_.transform(X_active)  # TODO: maybe fit_transform is faster
             if supplementary_columns:
-                X_sup = (
-                    preprocessing.StandardScaler(
-                        copy=self.copy,
-                        with_mean=self.rescale_with_mean,
-                        with_std=self.rescale_with_std,
-                    )
-                    .fit(X_sup, sample_weight=sample_weight)
-                    .transform(X_sup)
-                )
+                X_sup = preprocessing.StandardScaler(
+                    copy=self.copy,
+                    with_mean=self.rescale_with_mean,
+                    with_std=self.rescale_with_std,
+                ).fit_transform(X_sup, sample_weight=sample_weight)
 
         self._column_dist = pd.Series(
             (X_active**2 * sample_weight[:, np.newaxis]).sum(axis=0),

--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -112,26 +112,26 @@ class TestMFA:
 
     def test_col_coords(self):
         F = load_df_from_R("mfa$quanti.var$coord").iloc[:, : self.mfa.n_components]
-        P = self.mfa.column_coordinates_
         if self.sup_groups:
-            sup_cols = [col for col in P.index if col[0] == "2023-24"]
-            P = P.drop(sup_cols)
+            F_sup = load_df_from_R("mfa$quanti.var.sup$coord").iloc[:, : self.mfa.n_components]
+            F = pd.concat((F, F_sup))
+        P = self.mfa.column_coordinates_
         np.testing.assert_allclose(F.abs(), P.abs())
 
     def test_col_cor(self):
         F = load_df_from_R("mfa$quanti.var$cor").iloc[:, : self.mfa.n_components]
-        P = self.mfa.column_correlations
         if self.sup_groups:
-            sup_cols = [col for col in P.index if col[0] == "2023-24"]
-            P = P.drop(sup_cols)
+            F_sup = load_df_from_R("mfa$quanti.var.sup$cor").iloc[:, : self.mfa.n_components]
+            F = pd.concat((F, F_sup))
+        P = self.mfa.column_correlations
         np.testing.assert_allclose(F.abs(), P.abs())
 
     def test_col_cos2(self):
         F = load_df_from_R("mfa$quanti.var$cos2").iloc[:, : self.mfa.n_components]
-        P = self.mfa.column_cosine_similarities_
         if self.sup_groups:
-            sup_cols = [col for col in P.index if col[0] == "2023-24"]
-            P = P.drop(sup_cols)
+            F_sup = load_df_from_R("mfa$quanti.var.sup$cos2").iloc[:, : self.mfa.n_components]
+            F = pd.concat((F, F_sup))
+        P = self.mfa.column_cosine_similarities_
         np.testing.assert_allclose(F, P)
 
     def test_col_contrib(self):

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -166,16 +166,16 @@ class TestPCA:
 
     def test_col_coords(self):
         F = load_df_from_R("pca$var$coord")
-        P = self.pca.column_coordinates_
         if self.sup_cols:
-            P = P.drop(["rank", "points"])
+            F = pd.concat((F, load_df_from_R("pca$quanti.sup$coord")))
+        P = self.pca.column_coordinates_
         np.testing.assert_allclose(F.abs(), P.abs())
 
     def test_col_cos2(self):
         F = load_df_from_R("pca$var$cos2")
-        P = self.pca.column_cosine_similarities_
         if self.sup_cols:
-            P = P.drop(["rank", "points"])
+            F = pd.concat((F, load_df_from_R("pca$quanti.sup$cos2")))
+        P = self.pca.column_cosine_similarities_
         np.testing.assert_allclose(F, P)
 
     def test_col_contrib(self):


### PR DESCRIPTION
## Summary

- **Bug fix** in `prince/pca.py`: supplementary column coordinates were off by a factor of √n. The projection used `X_sup.T @ (U / √n)` instead of `X_sup.T @ (w * U)`, so coordinates exceeded [-1, 1] rather than being correlations with the components. Also fixed two related inconsistencies: `X_sup` is now standardized with `sample_weight`, and `_column_dist` for supplementary columns uses `sample_weight`. Under uniform weights this collapses to the user's proposed `(1/n) X_sup.T @ U` from #228, and matches FactoMineR's `pca$quanti.sup$coord` exactly.
- **Test gap**: `tests/test_pca.py::test_col_coords` previously dropped `rank` and `points` before comparing to FactoMineR. Same story in `tests/test_mfa.py` for supplementary groups. These now compare against `pca$quanti.sup$coord`/`$cos2` and `mfa$quanti.var.sup$coord`/`$cor`/`$cos2`.
- MFA inherits the fix since supplementary groups go through PCA; CA/MCA already had supplementary coverage; FAMD has no supplementary support so nothing to add.

## Test plan

- [x] `pytest tests/test_pca.py` — 320 passed (now exercises supplementary columns under every combination of scaling, sample weights, column weights)
- [x] `pytest tests/test_mfa.py` — 68 passed (now exercises supplementary group columns)
- [x] Full suite: 511 passed
- [x] Verified against FactoMineR on the decathlon dataset (uniform weights) and the Premier League dataset (MFA with supplementary group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)