### PR TITLE
Extend supplementary test coverage in PCA and MFA

### DIFF
--- a/tests/test_mfa.py
+++ b/tests/test_mfa.py
@@ -187,14 +187,22 @@ class TestMFA:
 
     def test_partial_row_coords(self):
         F = load_df_from_R("mfa$ind$coord.partiel").iloc[:, : self.mfa.n_components]
+        if self.sup_rows:
+            F_sup = load_df_from_R("mfa$ind.sup$coord.partiel").iloc[:, : self.mfa.n_components]
         P = self.mfa.partial_row_coordinates(self.dataset)
 
         active_groups = [g for g in self.groups if not self.sup_groups or g != "2023-24"]
         n_active_groups = len(active_groups)
+        sup_rows = ["Manchester City", "Manchester United"]
 
         for i, group in enumerate(active_groups):
             F_group = F.iloc[i::n_active_groups]
             P_group = P[group]
             if self.sup_rows:
-                P_group = P_group.drop(["Manchester City", "Manchester United"])
-            np.testing.assert_allclose(F_group.abs().values, P_group.abs().values)
+                P_group_active = P_group.drop(sup_rows)
+                np.testing.assert_allclose(F_group.abs().values, P_group_active.abs().values)
+                F_sup_group = F_sup.iloc[i::n_active_groups]
+                P_sup_group = P_group.loc[sup_rows]
+                np.testing.assert_allclose(F_sup_group.abs().values, P_sup_group.abs().values)
+            else:
+                np.testing.assert_allclose(F_group.abs().values, P_group.abs().values)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -182,3 +182,10 @@ class TestPCA:
         F = load_df_from_R("pca$var$contrib")
         P = self.pca.column_contributions_
         np.testing.assert_allclose(F, P * 100)
+
+    def test_col_cor(self):
+        F = load_df_from_R("pca$var$cor")
+        if self.sup_cols:
+            F = pd.concat((F, load_df_from_R("pca$quanti.sup$cor")))
+        P = self.pca.column_correlations
+        np.testing.assert_allclose(F.abs(), P.abs())


### PR DESCRIPTION
## Summary

Follow-up to #229. Closes the remaining supplementary-projection test gaps:

- **PCA**: adds `test_col_cor` comparing `column_correlations` against `pca$var$cor` and `pca$quanti.sup$cor`. Active correlations were never compared (matters only when `rescale_with_std=False`, where loadings and correlations diverge); supplementary correlations were also never compared.
- **MFA**: `test_partial_row_coords` no longer drops the supplementary rows before comparing — it now also asserts against `mfa$ind.sup$coord.partiel`. This is the same shape of gap that hid the bug fixed in #229: a `drop()` removing the supplementary path from the FactoMineR comparison.

## Out of scope

`mfa$group$coord.sup` and `mfa$group$cos2.sup` (supplementary group coordinates) are not tested here because Prince does not expose them — `group_coordinates_` only iterates over `_active_groups()`. That's a feature gap, not a test gap.

## Test plan

- [x] `pytest tests/test_pca.py` — 320 passed
- [x] `pytest tests/test_mfa.py` — 68 passed (now exercises partial coordinates for supplementary rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)