### PR TITLE
Test random_state determinism for fbpca and sklearn SVD engines

### DIFF
--- a/prince/svd.py
+++ b/prince/svd.py
@@ -41,11 +41,11 @@ def compute_svd(
     # Compute the SVD
     if engine == "fbpca":
         if FBPCA_INSTALLED:
-            if random_state:
+            if random_state is not None:
                 state = np.random.get_state()
                 np.random.seed(random_state)
             U, s, V = fbpca.pca(X, k=n_components, n_iter=n_iter)
-            if random_state:
+            if random_state is not None:
                 np.random.set_state(state)
         else:
             raise ValueError("fbpca is not installed; please install it if you want to use it")

--- a/tests/test_svd.py
+++ b/tests/test_svd.py
@@ -79,3 +79,44 @@ class TestSVD:
         P = self.svd.V
         F = load_df_from_R("svd$V").T
         np.testing.assert_allclose(np.abs(F), np.abs(P))
+
+
+@pytest.mark.parametrize("engine", ["fbpca", "sklearn"])
+class TestRandomState:
+    """random_state must produce reproducible SVDs regardless of the global
+    numpy random state, for every engine that exposes a random_state knob."""
+
+    X = np.random.RandomState(0).rand(500, 100)
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_engine_unavailable(self, engine):
+        if engine == "fbpca" and not svd.FBPCA_INSTALLED:
+            pytest.skip("fbpca is not installed")
+
+    def _svd(self, engine, random_state):
+        return svd.compute_svd(
+            X=self.X, n_components=5, n_iter=3, random_state=random_state, engine=engine
+        )
+
+    def test_same_seed_gives_identical_output(self, engine):
+        r1 = self._svd(engine, random_state=42)
+        np.random.rand(5)  # disturb the global numpy random state
+        r2 = self._svd(engine, random_state=42)
+        np.testing.assert_array_equal(r1.U, r2.U)
+        np.testing.assert_array_equal(r1.s, r2.s)
+        np.testing.assert_array_equal(r1.V, r2.V)
+
+    def test_different_seeds_give_different_output(self, engine):
+        r1 = self._svd(engine, random_state=42)
+        r2 = self._svd(engine, random_state=1)
+        assert not np.allclose(r1.U, r2.U)
+
+    def test_global_random_state_is_not_mutated(self, engine):
+        np.random.seed(99)
+        expected = np.random.rand(3)
+
+        np.random.seed(99)
+        self._svd(engine, random_state=42)
+        actual = np.random.rand(3)
+
+        np.testing.assert_array_equal(expected, actual)


### PR DESCRIPTION
Ports the testing from rtomek/prince#1 to this repo's master.

## Summary
- Adds `TestRandomState` covering both `fbpca` and `sklearn` engines:
  - **same seed → identical U/s/V**, even after the global numpy RNG is disturbed between calls (regression check for the fix in #227 for `fbpca`)
  - **different seeds → different output** (proves the seed is actually used, not silently ignored)
  - **global numpy RNG is not mutated** by the call (validates the save/restore around `fbpca.pca`)
- Changes the guard in `compute_svd` from `if random_state:` to `if random_state is not None:` so `random_state=0` still takes the seeded path.

## Test plan
- [x] `uv run pytest tests/test_svd.py::TestRandomState -v` — 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)