### PR TITLE
Use BLAS reductions for weighted sum-of-squares quantities

### DIFF
--- a/prince/ca.py
+++ b/prince/ca.py
@@ -94,7 +94,7 @@ class CA(sklearn.base.BaseEstimator, utils.EigenvaluesMixin):
         )
 
         # Compute total inertia
-        self.total_inertia_ = np.einsum("ij,ji->", S, S.T)
+        self.total_inertia_ = np.einsum("ij,ij->", S, S)
 
         self.row_contributions_ = pd.DataFrame(
             sparse.diags(self.row_masses_.values)

--- a/prince/mca.py
+++ b/prince/mca.py
@@ -110,8 +110,8 @@ class MCA(ca.CA, sklearn.base.TransformerMixin):
         """
         B = self._subset_full_burt_
         cm = B.sum(axis=0) / B.sum()
-        sqrt_cm_outer = np.sqrt(np.outer(cm, cm))
         cm_outer = np.outer(cm, cm)
+        sqrt_cm_outer = np.sqrt(cm_outer)
 
         # S_null: standardised residuals of the off-block-diagonal Burt.
         B_null = B - np.diag(np.diag(B))

--- a/prince/mfa.py
+++ b/prince/mfa.py
@@ -171,7 +171,9 @@ class MFA(pca.PCA, collections.UserDict):
             Z_g = Z.loc[:, block_cols].to_numpy(dtype=np.float64)
             S = Z_g.T @ Z_g / n
             w = column_weights[offset : offset + len(block_cols)]
-            self._group_dist2_[group] = float((S**2 * np.outer(w, w)).sum())
+            # sum_{j,k} S_jk^2 w_j w_k is the quadratic form w' (S∘S) w; the BLAS
+            # matvec route is several times faster than materialising S**2 and outer(w, w).
+            self._group_dist2_[group] = float(w @ (S * S) @ w)
             offset += len(block_cols)
 
         # The global PCA sees an already-scaled Z, so disable its scaler. We restore the
@@ -331,7 +333,7 @@ class MFA(pca.PCA, collections.UserDict):
     def row_cosine_similarities(self, X):
         Z_np = self._extract_Z_numpy(X)
         Z_scaled = self._scale_active_numpy(Z_np)
-        squared_coordinates = (np.square(Z_scaled) * self.column_weight_).sum(axis=1)
+        squared_coordinates = (Z_scaled * Z_scaled) @ self.column_weight_
         Z_scaled *= self.column_weight_
         coord = Z_scaled @ self.svd_.V.T
         return pd.DataFrame(
@@ -425,9 +427,9 @@ class MFA(pca.PCA, collections.UserDict):
         eig_ratios = np.array(eig_ratios_list)
 
         # Center and standardize with row weights
-        weighted_mean = (tab * row_weights[:, np.newaxis]).sum(axis=0)
+        weighted_mean = row_weights @ tab
         tab = tab - weighted_mean
-        sigma = np.sqrt((tab**2 * row_weights[:, np.newaxis]).sum(axis=0))
+        sigma = np.sqrt(row_weights @ (tab * tab))
         sigma[sigma < 1e-08] = 1
         tab = tab / sigma
 

--- a/prince/pca.py
+++ b/prince/pca.py
@@ -114,7 +114,7 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
                 ).fit_transform(X_sup, sample_weight=sample_weight)
 
         self._column_dist = pd.Series(
-            (X_active**2 * sample_weight[:, np.newaxis]).sum(axis=0),
+            sample_weight @ np.square(X_active),
             index=active_variables,
         )
         if supplementary_columns:
@@ -122,7 +122,7 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
                 (
                     self._column_dist,
                     pd.Series(
-                        (X_sup**2 * sample_weight[:, np.newaxis]).sum(axis=0),
+                        sample_weight @ np.square(X_sup),
                         index=supplementary_columns,
                     ),
                 )
@@ -138,9 +138,7 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
             column_weights=column_weight,
         )
 
-        self.total_inertia_ = np.sum(
-            np.square(X_active) * column_weight * sample_weight[:, np.newaxis]
-        )
+        self.total_inertia_ = sample_weight @ np.square(X_active) @ np.asarray(column_weight)
 
         self.column_coordinates_ = pd.DataFrame(
             data=self.svd_.V.T * self.eigenvalues_**0.5,
@@ -297,7 +295,8 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
         the squared cosine.
 
         """
-        squared_coordinates = (np.square(self._scale(X)) * self.column_weight_).sum(axis=1)
+        scaled = np.asarray(self._scale(X), dtype=np.float64)
+        squared_coordinates = (scaled * scaled) @ np.asarray(self.column_weight_)
         return (self.row_coordinates(X) ** 2).div(squared_coordinates, axis=0)
 
     @property


### PR DESCRIPTION
## What

Replaces broadcast-and-sum expressions for several weighted sum-of-squares quantities with equivalent BLAS dot/matvec forms across `ca.py`, `mca.py`, `mfa.py`, and `pca.py`:

| Site | Before | After |
|------|--------|-------|
| `pca.py` total inertia | `np.sum(X**2 * cw * sw[:,None])` | `sw @ X**2 @ cw` |
| `pca.py` column distances (active + supplementary) | `(X**2 * sw[:,None]).sum(axis=0)` | `sw @ X**2` |
| `pca.py` / `mfa.py` row cosine denominators | `(X**2 * w).sum(axis=1)` | `(X*X) @ w` |
| `mfa.py` group distances `Lg` | `(S**2 * outer(w,w)).sum()` | `w @ (S*S) @ w` |
| `mfa.py` column-coords centering/scaling | `(tab*rw[:,None]).sum(axis=0)` | `rw @ tab` |
| `ca.py` total inertia | `einsum("ij,ji->", S, S.T)` | `einsum("ij,ij->", S, S)` |
| `mca.py` Greenacre subset | `outer(cm,cm)` computed twice | computed once |

All changes are mathematically identical reformulations.

## Why

The BLAS forms allocate fewer large temporaries and run 2–5× faster per kernel (microbenchmarked). I also tried `np.einsum` for these, but the multi-operand einsums were actually *slower* than the originals because they bypass BLAS — the dot/matvec route is the real win.

## Honest impact

End-to-end this is **small**: the SVD/eigendecomposition dominates `fit()`, so `PCA.fit`/`MCA.fit` wall-clock is unchanged within noise. The measurable gains are on the `row_cosine_similarities` transform paths (~6–15%), which have no SVD. The primary benefits are **reduced memory churn** (no full `n×p` weighted temporaries) and **clearer intent**.

## Testing

- Full suite: 662 passed, 2 skipped (pre-existing PGA skips)
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)