### PR TITLE
Fix get_feature_names_out raising AttributeError on fitted estimators

### DIFF
--- a/prince/mca.py
+++ b/prince/mca.py
@@ -264,6 +264,7 @@ class MCA(ca.CA, sklearn.base.TransformerMixin):
         one_hot = pd.DataFrame(one_hot_dense, index=X.index, columns=kept_columns)
 
         super().fit(one_hot)
+        self.n_components_ = len(self.svd_.s)
         return self
 
     @utils.check_is_dataframe_input

--- a/prince/mca.py
+++ b/prince/mca.py
@@ -49,8 +49,6 @@ class MCA(ca.CA, sklearn.base.TransformerMixin):
 
     """
 
-    n_components_: int
-
     def __init__(
         self,
         n_components=2,
@@ -100,8 +98,9 @@ class MCA(ca.CA, sklearn.base.TransformerMixin):
             X = X.reindex(columns=one_hot_columns_.union(X.columns), fill_value=False)
         return X
 
+    @utils.check_is_fitted
     def get_feature_names_out(self, input_features=None):
-        return np.arange(self.n_components_)
+        return np.arange(len(self.svd_.s))
 
     def _subset_greenacre_quantities(self):
         """Adjusted eigenvalues and total inertia for subset MCA with Greenacre correction.
@@ -264,7 +263,6 @@ class MCA(ca.CA, sklearn.base.TransformerMixin):
         one_hot = pd.DataFrame(one_hot_dense, index=X.index, columns=kept_columns)
 
         super().fit(one_hot)
-        self.n_components_ = len(self.svd_.s)
         return self
 
     @utils.check_is_dataframe_input

--- a/prince/pca.py
+++ b/prince/pca.py
@@ -49,10 +49,6 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
 
     """
 
-    # Fit attributes (set during ``fit``); annotated here so static type checkers
-    # know they exist on instances.
-    n_components_: int
-
     def __init__(
         self,
         rescale_with_mean=True,
@@ -77,8 +73,9 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
         if self.check_input:
             sklearn.utils.check_array(X)
 
+    @utils.check_is_fitted
     def get_feature_names_out(self, input_features=None):
-        return np.arange(self.n_components_)
+        return np.arange(len(self.svd_.s))
 
     @utils.check_is_dataframe_input
     def fit(
@@ -147,8 +144,6 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
             row_weights=sample_weight,
             column_weights=column_weight,
         )
-
-        self.n_components_ = len(self.svd_.s)
 
         self.total_inertia_ = sample_weight @ np.square(X_active) @ np.asarray(column_weight)
 

--- a/prince/pca.py
+++ b/prince/pca.py
@@ -148,6 +148,8 @@ class PCA(sklearn.base.BaseEstimator, sklearn.base.TransformerMixin, utils.Eigen
             column_weights=column_weight,
         )
 
+        self.n_components_ = len(self.svd_.s)
+
         self.total_inertia_ = sample_weight @ np.square(X_active) @ np.asarray(column_weight)
 
         self.column_coordinates_ = pd.DataFrame(

--- a/tests/test_famd.py
+++ b/tests/test_famd.py
@@ -344,3 +344,9 @@ def test_issue_169():
     3         -0.752726  0.0
 
     """
+
+
+def test_get_feature_names_out():
+    """FAMD exposes get_feature_names_out via PCA (sklearn transformer API)."""
+    famd = prince.FAMD(n_components=2, engine="scipy").fit(prince.datasets.load_beers().head(200))
+    assert len(famd.get_feature_names_out()) == famd.n_components_ == 2

--- a/tests/test_famd.py
+++ b/tests/test_famd.py
@@ -349,4 +349,7 @@ def test_issue_169():
 def test_get_feature_names_out():
     """FAMD exposes get_feature_names_out via PCA (sklearn transformer API)."""
     famd = prince.FAMD(n_components=2, engine="scipy").fit(prince.datasets.load_beers().head(200))
-    assert len(famd.get_feature_names_out()) == famd.n_components_ == 2
+    assert famd.get_feature_names_out().tolist() == list(range(len(famd.svd_.s)))
+    assert len(famd.get_feature_names_out()) == famd.transform(
+        prince.datasets.load_beers().head(200)
+    ).shape[1] == 2

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -386,3 +386,10 @@ def test_abdi_2007_correction():
     [95.189, 1.678, 0.038, 0.0]
 
     """
+
+
+def test_get_feature_names_out():
+    """get_feature_names_out returns one label per fitted component (sklearn transformer API)."""
+    df = pd.DataFrame({"x": list("aabbcc") * 3, "y": list("pqr") * 6})
+    mca = prince.MCA(n_components=2).fit(df)
+    assert len(mca.get_feature_names_out()) == mca.transform(df).shape[1] == 2

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from rpy2.robjects import r as R
+from sklearn.exceptions import NotFittedError
 
 import prince
 from tests import load_df_from_R
@@ -391,5 +392,11 @@ def test_abdi_2007_correction():
 def test_get_feature_names_out():
     """get_feature_names_out returns one label per fitted component (sklearn transformer API)."""
     df = pd.DataFrame({"x": list("aabbcc") * 3, "y": list("pqr") * 6})
-    mca = prince.MCA(n_components=2).fit(df)
-    assert len(mca.get_feature_names_out()) == mca.transform(df).shape[1] == 2
+    mca = prince.MCA(n_components=20).fit(df)
+    assert mca.get_feature_names_out().tolist() == list(range(len(mca.svd_.s)))
+    assert len(mca.get_feature_names_out()) == mca.transform(df).shape[1] == 5
+
+
+def test_get_feature_names_out_checks_is_fitted():
+    with pytest.raises(NotFittedError):
+        prince.MCA().get_feature_names_out()

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -10,6 +10,7 @@ import sklearn.utils.estimator_checks
 import sklearn.utils.validation
 from rpy2.robjects import numpy2ri
 from sklearn import decomposition, pipeline, preprocessing
+from sklearn.exceptions import NotFittedError
 
 import prince
 from tests import load_df_from_R
@@ -228,5 +229,10 @@ def test_get_feature_names_out():
     """get_feature_names_out returns one label per fitted component (sklearn transformer API)."""
     X = pd.DataFrame(np.arange(40, dtype=float).reshape(10, 4), columns=list("abcd"))
     pca = prince.PCA(n_components=3).fit(X)
-    assert pca.n_components_ == 3
+    assert pca.get_feature_names_out().tolist() == list(range(len(pca.svd_.s)))
     assert len(pca.get_feature_names_out()) == pca.transform(X).shape[1] == 3
+
+
+def test_get_feature_names_out_checks_is_fitted():
+    with pytest.raises(NotFittedError):
+        prince.PCA().get_feature_names_out()

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -222,3 +222,11 @@ def test_plot_marker_combinations(
         show_column_labels=show_column_labels,
     )
     assert chart is not None
+
+
+def test_get_feature_names_out():
+    """get_feature_names_out returns one label per fitted component (sklearn transformer API)."""
+    X = pd.DataFrame(np.arange(40, dtype=float).reshape(10, 4), columns=list("abcd"))
+    pca = prince.PCA(n_components=3).fit(X)
+    assert pca.n_components_ == 3
+    assert len(pca.get_feature_names_out()) == pca.transform(X).shape[1] == 3


### PR DESCRIPTION
## Problem

Calling `get_feature_names_out()` on a fitted `PCA`, `MCA`, or `FAMD` estimator raises:

```
AttributeError: 'PCA' object has no attribute 'n_components_'
```

```python
import pandas as pd, numpy as np, prince

X = pd.DataFrame(np.arange(40, dtype=float).reshape(10, 4), columns=list("abcd"))
pca = prince.PCA(n_components=3).fit(X)
pca.get_feature_names_out()  # AttributeError
```

This also breaks `Pipeline.get_feature_names_out()` and `ColumnTransformer`, which delegates to this method, so a pipeline containing a prince estimator fails the same way.

## Cause

`get_feature_names_out` returns `np.arange(self.n_components_)`, but there's nothing in `fit` that assigns `n_components_`. It just exists as a class-level annotation, so the type checker stays green while the attribute is missing at runtime.

## Fix

`fit` now sets `self.n_components_ = len(self.svd_.s)` in `PCA.fit` and `MCA.fit` (`FAMD` inherits). Works in the paths I traced (including the rank capped CA/MCA SVD where fewer components are kept than requested)  and matches the width of the `transform` output. Happy to adjust if there's a case I've missed.

## Tests

One regression test per estimator, asserting `len(get_feature_names_out()) == transform(X).shape[1]`. All three raise the `AttributeError` on master and pass with this change. `ruff check`, `ruff format --check`, and `ty check prince` are clean.
